### PR TITLE
Increase jwt token expires in to 90min

### DIFF
--- a/src/base_modules/auth/constants.ts
+++ b/src/base_modules/auth/constants.ts
@@ -1,5 +1,5 @@
 /* Defines how long a JWT Token lives, after creation */
-export const CONST_JWT_TOKEN_EXPIRES_IN = '10m'; // 10 minutes
+export const CONST_JWT_TOKEN_EXPIRES_IN = '90m'; // 90 minutes
 
 /* Defines how long a JWT Refresh Token lives, after creation */
 export const CONST_REFRESH_JWT_TOKEN_EXPIRES_IN = '7d'; // 7 days


### PR DESCRIPTION
Token lifetime was too short (10min).
Users were experiencing logouts.
To avoid that, we increase it to 90min.