### PR TITLE
Fix-error-during-project-import

### DIFF
--- a/.cloud/docker/Dockerfile
+++ b/.cloud/docker/Dockerfile
@@ -24,6 +24,7 @@ FROM node:23.11.0-alpine AS api
 ARG USERNAME
 RUN adduser -D ${USERNAME}
 USER ${USERNAME}
+RUN mkdir /home/${USERNAME}/private
 WORKDIR /home/${USERNAME}/app
 # Copy only necessary files
 COPY --chown=${USERNAME}:${USERNAME} --from=api-build /app/dist ./dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.0.14-alpha",
+  "version": "0.0.15-alpha",
   "description": "",
   "author": "",
   "private": true,

--- a/src/base_modules/file/file.controller.ts
+++ b/src/base_modules/file/file.controller.ts
@@ -103,7 +103,9 @@ export class FileController {
         const cleanedFileName = escapeString(file_name);
         const cleanedProjectId = escapeString(project_id);
         const cleanedOrgId = escapeString(org_id);
-        const filePath = join('/private', cleanedOrgId, cleanedProjectId, cleanedFileName);
+
+        const downloadPath = process.env.DOWNLOAD_PATH || '/private';
+        const filePath = join(downloadPath, cleanedOrgId, cleanedProjectId, cleanedFileName);
         return new Promise((resolve, reject) => {
             return readFile(filePath, 'utf8', (err, data) => {
                 if (err) {

--- a/src/base_modules/file/file.service.ts
+++ b/src/base_modules/file/file.service.ts
@@ -57,7 +57,8 @@ export class FileService {
         const added_by = await this.usersRepository.getUserById(user.userId);
 
         // Define the folder path where the file will be saved
-        const folderPath = join('/private', project.added_by.id, escapeProjectId);
+        const downloadPath = process.env.DOWNLOAD_PATH || '/private';
+        const folderPath = join(downloadPath, project.added_by.id, escapeProjectId);
 
         // Create the folder path if it doesn't exist
         if (!fs.existsSync(folderPath)) {
@@ -233,7 +234,8 @@ export class FileService {
         const file = await this.fileRepository.getById(file_id, added_by);
 
         // Define the file path
-        const filePath = join('/private', project.added_by.id, escapeProjectId, file.name);
+        const downloadPath = process.env.DOWNLOAD_PATH || '/private';
+        const filePath = join(downloadPath, project.added_by.id, escapeProjectId, file.name);
 
         // Delete the file from the file system if it exists
         if (fs.existsSync(filePath)) {

--- a/src/base_modules/projects/projects.service.ts
+++ b/src/base_modules/projects/projects.service.ts
@@ -160,7 +160,8 @@ export class ProjectService {
 
         const added_project = await this.projectsRepository.saveProject(project);
 
-        const folderPath = join('/private', organization.id, 'projects', added_project.id);
+        const downloadPath = process.env.DOWNLOAD_PATH || '/private';
+        const folderPath = join(downloadPath, organization.id, 'projects', added_project.id);
         await mkdir(folderPath, { recursive: true });
 
         await this.organizationLoggerService.addAuditLog(
@@ -304,7 +305,8 @@ export class ProjectService {
         }
 
         // Remove project folder
-        const filePath = join('/private', organization.id, 'projects', project.id);
+        const downloadPath = process.env.DOWNLOAD_PATH || '/private';
+        const filePath = join(downloadPath, organization.id, 'projects', project.id);
         if (existsSync(filePath)) {
             await rm(filePath, { recursive: true, force: true });
         }


### PR DESCRIPTION
Projects import generated an error as the folder where the projects were supposed to be created didn't exist.

The folder is now binded in the container with proper rights.