### PR TITLE
Add VLAI fields and update version to 0.0.28-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.0.27-alpha",
+  "version": "0.0.28-alpha",
   "description": "",
   "author": "",
   "private": true,

--- a/src/codeclarity_modules/knowledge/nvd/nvd.entity.ts
+++ b/src/codeclarity_modules/knowledge/nvd/nvd.entity.ts
@@ -45,7 +45,7 @@ export class NVD {
     @Expose()
     vlai_score: string;
 
-    @Column({ nullable: true })
+    @Column('float', { nullable: true })
     @ApiProperty()
     @Expose()
     vlai_confidence: number;

--- a/src/codeclarity_modules/knowledge/nvd/nvd.entity.ts
+++ b/src/codeclarity_modules/knowledge/nvd/nvd.entity.ts
@@ -40,6 +40,16 @@ export class NVD {
     @Expose()
     descriptions: any;
 
+    @Column({ nullable: true })
+    @ApiProperty()
+    @Expose()
+    vlai_score: string;
+
+    @Column({ nullable: true })
+    @ApiProperty()
+    @Expose()
+    vlai_confidence: number;
+
     @Column('jsonb', { nullable: true })
     @ApiProperty()
     @Expose()

--- a/src/codeclarity_modules/knowledge/osv/osv.entity.ts
+++ b/src/codeclarity_modules/knowledge/osv/osv.entity.ts
@@ -25,7 +25,7 @@ export class OSV {
     @Expose()
     vlai_score: string;
 
-    @Column({ nullable: true })
+    @Column('float', { nullable: true })
     @ApiProperty()
     @Expose()
     vlai_confidence: number;

--- a/src/codeclarity_modules/knowledge/osv/osv.entity.ts
+++ b/src/codeclarity_modules/knowledge/osv/osv.entity.ts
@@ -23,6 +23,16 @@ export class OSV {
     @Column({ nullable: true })
     @ApiProperty()
     @Expose()
+    vlai_score: string;
+
+    @Column({ nullable: true })
+    @ApiProperty()
+    @Expose()
+    vlai_confidence: number;
+
+    @Column({ nullable: true })
+    @ApiProperty()
+    @Expose()
     modified: string;
 
     @Column({ nullable: true })

--- a/src/codeclarity_modules/results/vulnerabilities/vulnerabilities.service.ts
+++ b/src/codeclarity_modules/results/vulnerabilities/vulnerabilities.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PaginatedResponse } from 'src/types/apiResponses.types';
 import {
     AffectedVuln,
+    Source,
     Vulnerability,
     VulnerabilityMerged
 } from 'src/codeclarity_modules/results/vulnerabilities/vulnerabilities.types';
@@ -456,8 +457,23 @@ export class VulnerabilitiesService {
                     Weaknesses: finding.Weaknesses,
                     Affected: [affected],
                     Description: '',
-                    Conflict: finding.Conflict
+                    Conflict: finding.Conflict,
+                    VLAI: []
                 };
+                if (finding.NVDMatch) {
+                    mergedFinding.VLAI.push({
+                        Source: Source.Nvd,
+                        Score: finding.NVDMatch.Vulnerability.Vlai_score,
+                        Confidence: finding.NVDMatch.Vulnerability.Vlai_confidence
+                    })
+                }
+                if (finding.OSVMatch) {
+                    mergedFinding.VLAI.push({
+                        Source: Source.Osv,
+                        Score: finding.OSVMatch.Vulnerability.Vlai_score,
+                        Confidence: finding.OSVMatch.Vulnerability.Vlai_confidence
+                    });
+                }
                 findingsMerged.set(finding.VulnerabilityId, mergedFinding);
             }
         }

--- a/src/codeclarity_modules/results/vulnerabilities/vulnerabilities.types.ts
+++ b/src/codeclarity_modules/results/vulnerabilities/vulnerabilities.types.ts
@@ -211,6 +211,13 @@ export interface VulnerabilityMerged {
     Weaknesses?: WeaknessInfo[];
     Description: string;
     Conflict: Conflict;
+    VLAI: VLAI[];
+}
+
+export interface VLAI {
+    Source: Source;
+    Score: string;
+    Confidence: number;
 }
 
 export interface AffectedVuln {


### PR DESCRIPTION
Introduce new fields for VLAI in NVD and OSV entities, change the type of the vlai_confidence column, and update the VulnerabilityMerged interface to include VLAI data. Bump the version in package.json to 0.0.28-alpha.