### PR TITLE
Fix file upload endpoint for local project uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.0.45-alpha",
+  "version": "0.0.46-alpha",
   "description": "",
   "author": "",
   "private": true,

--- a/src/base_modules/file/file.controller.ts
+++ b/src/base_modules/file/file.controller.ts
@@ -38,7 +38,7 @@ export interface UploadData {
   hash: string;
 }
 
-@Controller("/file/:project_id")
+@Controller("/org/:organization_id/file/:project_id")
 export class FileController {
   constructor(private readonly fileService: FileService) {}
 
@@ -102,17 +102,17 @@ export class FileController {
   @ApiErrorDecorator({ statusCode: 404, errors: [EntityNotFound] })
   @ApiErrorDecorator({ statusCode: 403, errors: [NotAuthorized] })
   @ApiErrorDecorator({ statusCode: 500, errors: [InternalError] })
-  @Get(":project_id")
+  @Get(":file_name")
   async getFileByName(
     @AuthUser() _user: AuthenticatedUser,
     @Param("project_id") project_id: string,
-    @Param("org_id") org_id: string,
+    @Param("organization_id") organization_id: string,
     @Param("file_name") file_name: string,
   ): Promise<TypedResponse<string>> {
     const downloadPath = process.env["DOWNLOAD_PATH"] ?? "/private";
     const filePath = validateAndJoinPath(
       downloadPath,
-      org_id,
+      organization_id,
       project_id,
       file_name,
     );

--- a/src/base_modules/file/file.service.ts
+++ b/src/base_modules/file/file.service.ts
@@ -58,10 +58,11 @@ export class FileService {
     const added_by = await this.usersRepository.getUserById(user.userId);
 
     // Define the folder path where the file will be saved
+    // Use the current user's ID for the folder path (user uploading the file)
     const downloadPath = process.env["DOWNLOAD_PATH"] ?? "/private";
     const folderPath = validateAndJoinPath(
       downloadPath,
-      project.added_by.id,
+      added_by.id,
       project_id,
     );
 
@@ -244,8 +245,8 @@ export class FileService {
       MemberRole.USER,
     );
 
-    // Retrieve the project by ID and organization ID
-    const project = await this.projectsRepository.getProjectByIdAndOrganization(
+    // Verify the project exists and belongs to the organization
+    await this.projectsRepository.getProjectByIdAndOrganization(
       project_id,
       organization_id,
     );
@@ -257,10 +258,11 @@ export class FileService {
     const file = await this.fileRepository.getById(file_id, added_by);
 
     // Define the file path
+    // Use the current user's ID for the folder path
     const downloadPath = process.env["DOWNLOAD_PATH"] ?? "/private";
     const filePath = validateAndJoinPath(
       downloadPath,
-      project.added_by.id,
+      added_by.id,
       project_id,
       file.name,
     );


### PR DESCRIPTION
- Add organization_id to file controller route path
- Use current user's ID for file storage path instead of project.added_by
- Fix parameter naming consistency (org_id -> organization_id)